### PR TITLE
Add an option to use the native file picker

### DIFF
--- a/src/main/java/com/minelittlepony/hdskins/client/HDConfig.java
+++ b/src/main/java/com/minelittlepony/hdskins/client/HDConfig.java
@@ -8,6 +8,7 @@ import com.minelittlepony.common.util.settings.*;
 public class HDConfig extends Config {
 
     public final Setting<Path> lastChosenFile = value("lastChosenFile", Paths.get("/"));
+    public final Setting<Boolean> useNativeFileChooser = value("useNativeFileChooser", false);
 
     public HDConfig(Path path) {
         super(FLATTENED_JSON_ADAPTER, path);

--- a/src/main/java/com/minelittlepony/hdskins/client/filedialog/AbstractNativeFileDialog.java
+++ b/src/main/java/com/minelittlepony/hdskins/client/filedialog/AbstractNativeFileDialog.java
@@ -1,0 +1,53 @@
+package com.minelittlepony.hdskins.client.filedialog;
+
+import com.minelittlepony.hdskins.client.HDSkins;
+import net.minecraft.client.MinecraftClient;
+import org.jetbrains.annotations.Nullable;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+abstract class AbstractNativeFileDialog implements FileDialog {
+    private static final Executor executor = Executors.newSingleThreadExecutor();
+
+    protected Path currentDirectory = HDSkins.getInstance().getConfig().lastChosenFile.get();
+
+    @Nullable
+    protected String extensionFilter;
+    @Nullable
+    protected String filterMessage;
+    private Callback callback = (file, done) -> {};
+
+    @Override
+    public FileDialog filter(String extension, String description) {
+
+        this.extensionFilter = extension;
+        this.filterMessage = description;
+        return this;
+    }
+    @Override
+    public FileDialog andThen(Callback callback) {
+        this.callback = callback;
+        return this;
+    }
+
+    @Nullable
+    protected abstract String runFileDialog();
+
+    @Override
+    public FileDialog launch() {
+        CompletableFuture.supplyAsync(() -> {
+            var file = runFileDialog();
+            if (file == null) {
+                return null;
+            }
+            return Paths.get(file);
+        }, executor).thenAcceptAsync(result -> {
+            callback.onDialogClosed(result, true);
+        }, MinecraftClient.getInstance());
+        return this;
+    }
+}

--- a/src/main/java/com/minelittlepony/hdskins/client/filedialog/FileDialog.java
+++ b/src/main/java/com/minelittlepony/hdskins/client/filedialog/FileDialog.java
@@ -1,14 +1,13 @@
-package com.minelittlepony.hdskins.client;
+package com.minelittlepony.hdskins.client.filedialog;
 
 import java.nio.file.Path;
 
 /**
  * A file dialog for opening and reading files.
- * 
+ * <p>
  * Implementations may vary.
  */
 public interface FileDialog {
-
     /**
      * Called to filter the types of files this dialogue is allowed to work with.
      */
@@ -25,7 +24,7 @@ public interface FileDialog {
     FileDialog launch();
 
     @FunctionalInterface
-    public interface Callback {
+    interface Callback {
         void onDialogClosed(Path file, boolean success);
     }
 }

--- a/src/main/java/com/minelittlepony/hdskins/client/filedialog/FileDialogs.java
+++ b/src/main/java/com/minelittlepony/hdskins/client/filedialog/FileDialogs.java
@@ -1,0 +1,11 @@
+package com.minelittlepony.hdskins.client.filedialog;
+
+public interface FileDialogs {
+
+    FileDialogs guiFD = new GuiFileDialogs();
+    FileDialogs nativeFD = new NativeFileDialogs();
+
+    FileDialog open(String title);
+
+    FileDialog save(String title, String filename);
+}

--- a/src/main/java/com/minelittlepony/hdskins/client/filedialog/GuiFileDialogs.java
+++ b/src/main/java/com/minelittlepony/hdskins/client/filedialog/GuiFileDialogs.java
@@ -1,0 +1,16 @@
+package com.minelittlepony.hdskins.client.filedialog;
+
+import com.minelittlepony.hdskins.client.gui.FileSaverScreen;
+import com.minelittlepony.hdskins.client.gui.FileSelectorScreen;
+
+class GuiFileDialogs implements FileDialogs {
+    @Override
+    public FileDialog open(String title) {
+        return new FileSelectorScreen(title);
+    }
+
+    @Override
+    public FileDialog save(String title, String filename) {
+        return new FileSaverScreen(title, filename);
+    }
+}

--- a/src/main/java/com/minelittlepony/hdskins/client/filedialog/NativeFileDialogs.java
+++ b/src/main/java/com/minelittlepony/hdskins/client/filedialog/NativeFileDialogs.java
@@ -1,0 +1,47 @@
+package com.minelittlepony.hdskins.client.filedialog;
+
+import org.jetbrains.annotations.Nullable;
+import org.lwjgl.PointerBuffer;
+import org.lwjgl.util.tinyfd.TinyFileDialogs;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+class NativeFileDialogs implements FileDialogs {
+    @Override
+    public FileDialog open(String title) {
+        return new AbstractNativeFileDialog() {
+            @Override
+            @Nullable
+            protected String runFileDialog() {
+                return TinyFileDialogs.tinyfd_openFileDialog(title, this.currentDirectory.toString(), getFilterBuffer(this.extensionFilter), this.filterMessage, false);
+            }
+        };
+    }
+
+    @Override
+    public FileDialog save(String title, String filename) {
+        return new AbstractNativeFileDialog() {
+            @Override
+            @Nullable
+            protected String runFileDialog() {
+                if (Files.isDirectory(this.currentDirectory)) {
+                    this.currentDirectory = this.currentDirectory.resolve(filename);
+                } else {
+                    this.currentDirectory = this.currentDirectory.resolveSibling(filename);
+                }
+
+                return TinyFileDialogs.tinyfd_saveFileDialog(title, this.currentDirectory.toString(), getFilterBuffer(this.extensionFilter), this.filterMessage);
+            }
+        };
+    }
+
+    private static PointerBuffer getFilterBuffer(@Nullable String filter) {
+        if (filter == null) {
+            return null;
+        }
+        return PointerBuffer.create(ByteBuffer.wrap(filter.getBytes(StandardCharsets.UTF_8)));
+
+    }
+}

--- a/src/main/java/com/minelittlepony/hdskins/client/gui/FileSaverScreen.java
+++ b/src/main/java/com/minelittlepony/hdskins/client/gui/FileSaverScreen.java
@@ -5,7 +5,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import com.minelittlepony.common.client.gui.element.Button;
-import com.minelittlepony.hdskins.client.FileDialog;
+import com.minelittlepony.hdskins.client.filedialog.FileDialog;
 import com.minelittlepony.hdskins.util.net.FileTypes;
 
 import net.minecraft.text.Text;

--- a/src/main/java/com/minelittlepony/hdskins/client/gui/FileSelectorScreen.java
+++ b/src/main/java/com/minelittlepony/hdskins/client/gui/FileSelectorScreen.java
@@ -14,7 +14,7 @@ import com.minelittlepony.common.client.gui.element.Button;
 import com.minelittlepony.common.client.gui.element.Label;
 import com.minelittlepony.common.client.gui.packing.GridPacker;
 import com.minelittlepony.common.client.gui.sprite.TextureSprite;
-import com.minelittlepony.hdskins.client.FileDialog;
+import com.minelittlepony.hdskins.client.filedialog.FileDialog;
 import com.minelittlepony.hdskins.client.HDConfig;
 import com.minelittlepony.hdskins.client.HDSkins;
 import com.minelittlepony.hdskins.util.net.FileTypes;


### PR DESCRIPTION
Powered by TinyFD.

Trying 092d462ce88175dd50db3fab474c837027d791fc again. This time, it's configurable via `useNativeFileChooser`, which defaults to `false`.