### PR TITLE
Convert SkinUpload to a sealed interface 

### DIFF
--- a/src/main/java/com/minelittlepony/hdskins/server/SkinUpload.java
+++ b/src/main/java/com/minelittlepony/hdskins/server/SkinUpload.java
@@ -2,20 +2,27 @@ package com.minelittlepony.hdskins.server;
 
 import net.minecraft.client.util.Session;
 
-import org.jetbrains.annotations.Nullable;
 import com.minelittlepony.hdskins.profile.SkinType;
 
 import java.net.URI;
+import java.nio.file.Path;
 import java.util.Map;
 
-public record SkinUpload(
-        Session session,
-        SkinType type,
-        @Nullable URI image,
-        Map<String, String> metadata
-) {
+public sealed interface SkinUpload permits SkinUpload.FileUpload, SkinUpload.UriUpload, SkinUpload.Delete {
 
-    public String getSchemaAction() {
-        return image == null ? "none" : image.getScheme();
+    Session session();
+
+    SkinType type();
+
+    record FileUpload(Session session, SkinType type, Path file, Map<String, String> metadata)
+            implements SkinUpload {
+    }
+
+    record UriUpload(Session session, SkinType type, URI uri, Map<String, String> metadata)
+            implements SkinUpload {
+    }
+
+    record Delete(Session session, SkinType type)
+            implements SkinUpload {
     }
 }


### PR DESCRIPTION
with delete, file, and uri implementations.

This is cleaner than using a switch and a nullable `skin` attribute. It's better to omit the field all together. As a benefit, we can make the `FileUpload` accept a `Path` directly instead of converting it from a `URI` manually.

Once Minecraft uses a Java version that has [functional pattern matching](https://docs.oracle.com/en/java/javase/20/language/pattern-matching-switch-expressions-and-statements.html) as non-preview, we can use that via

```java
switch (upload) {
    case SkinUpload.Delete -> ...;
    case SkinUpload.FileUpload fileUpload -> ...;
    case SkinUpload.UriUpload uriUpload -> ...;
    default -> throw new IllegalArgumentException();
}
```